### PR TITLE
Updated Pandoc Command line options

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-pandoc --latex-engine=xelatex -o book.pdf 1.md 2.md 3.md 4.md 5.md 6.md 7.md 8.md 9.md 10.md 11.md 12.md 13.md 14.md 15.md 16.md 17.md 18.md 19.md 20.md
+pandoc --pdf-engine=xelatex -o book.pdf 1.md 2.md 3.md 4.md 5.md 6.md 7.md 8.md 9.md 10.md 11.md 12.md 13.md 14.md 15.md 16.md 17.md 18.md 19.md 20.md


### PR DESCRIPTION
As of at least `pandoc 2.7.3` the `--latex-engine` option has been replaced with
the -`-pdf-engine` option. This would not build without this change
applied.