### PR TITLE
Clarify instructions for password-less SSH login

### DIFF
--- a/01.md
+++ b/01.md
@@ -26,7 +26,7 @@ For example:
 
 	ssh support@192.123.321.99
 
-If you've setup to use a public keypair, then you'll need to point to the location of the public part as proof of identity with the "_-i_" switch, typically like this:
+If you have configured the remote server with your SSH public key (see "Password-less SSH login" in the [EXTENSION](#extension) section of this post), then you'll need to point to the location of the public part as proof of identity with the "_-i_" switch, typically like this:
 
     ssh -i ~/.ssh/id_rsa support@192.123.321.99
 


### PR DESCRIPTION
Aims to make explicit _how_ one must set up an SSH key pair before using password-less login by referencing the relevant resources in the 'extensions' section of the post. This is intended to avoid the confusion I experienced having 'setup' an SSH key pair locally, but without configuring the remote server to authorize my public key.