### PR TITLE
Add link to SSH client configuration resource in EXTENSIONS

### DIFF
--- a/01.md
+++ b/01.md
@@ -30,6 +30,8 @@ If you've setup to use a public keypair, then you'll need to point to the locati
 
     ssh -i ~/.ssh/id_rsa support@192.123.321.99
 
+See "SSH client configuration" in the [EXTENSION](#extension) section for details of how to configure `ssh` to simplify the above command.
+
 On an MacOS machine you'll normally access the command line via Terminal.app - it's in the Utilities sub-folder of Applications. On Linux distributions with a menu you'll typically find it under "Applications menu -> Accessories -> Terminal", "Applications menu -> System -> Terminal" or "Menu -> System -> Terminal Program (Konsole)"- or you can simply search for your terminal application.
 
 On recent Windows 10 versions, the same command-line client is now available, but must be enabled (via "Settings", "Apps", "Apps & features", "Manage optional features", "Add a feature", "OpenSSH client". 
@@ -84,6 +86,7 @@ If this is all too easy, then spend some time reading up on:
 
 * "SSH Tunneling" (e.g. https://linuxize.com/post/how-to-setup-ssh-tunneling/)
 * "Password-less SSH login" (e.g. https://linuxize.com/post/how-to-setup-passwordless-ssh-login/)
+* "SSH client configuration" (e.g. https://linuxize.com/post/using-the-ssh-config-file/)
 
 ## RESOURCES
 


### PR DESCRIPTION
Point out that it is possible to simplify the command used to connect to your server via SSH by using the `ssh` config file. Provide a link to a tutorial on configuring `ssh` in the EXTENSIONS section of the post.