### PR TITLE
Change `command` to `normal` in 06.md

### DIFF
--- a/06.md
+++ b/06.md
@@ -19,9 +19,11 @@ to check.
 * There are two "modes" - with very different behaviours
 * Little or nothing onscreen lets you know which mode you're currently in!
 
-The two modes are "command mode" and "editing mode", and as a beginner, there is one simple technique to remember - simply:
+The two modes are "normal mode" and "insert mode", and as a beginner, there is one simple technique to remember - simply:
 
-`"Press Esc twice or more to return to command mode"`
+`"Press Esc twice or more to return to normal mode"`
+
+The "normal mode" is used to input commands, and the "insert mode" is used for writting text. This last mode is vim's equivalent to regular text editor's default behaviour, like the previously seen `nano`.
 
 ## INSTRUCTIONS
 
@@ -32,9 +34,9 @@ So, first grab a text file to edit. A copy of `/etc/services` will do nicely:
      cp -v /etc/services testfile   
      vim testfile
 
-At this point we have the file on screen, and we are in "command mode". Unlike `nano`, however, there’s no onscreen menu and it's not at all obvious how anything works!
+At this point we have the file on screen, and we are in "normal mode". Unlike `nano`, however, there’s no onscreen menu and it's not at all obvious how anything works!
 
-Start by pressing _Esc_ once or twice to ensure that we are in command mode (remember this trick from above), then type `:q!` and press _Enter_. This quits without saving any changes - a _vital_ first skill when you don't yet know what you're doing!
+Start by pressing _Esc_ once or twice to ensure that we are in normal mode (remember this trick from above), then type `:q!` and press _Enter_. This quits without saving any changes - a _vital_ first skill when you don't yet know what you're doing!
 Now let's go in again and play around, seeing how powerful and dangerous `vim` is - then again, quit without saving:
 
      vim testfile
@@ -49,20 +51,20 @@ Now that you've mastered that, lets get more advanced.
 
 This time, move down a few lines into the file and press _3_ then _3_ again, then _d_ and _d_ again - and suddenly 33 lines of the file are deleted! 
 
-Why? Well, you are in command mode and _33dd_ is a command that says "delete 33 lines". Now, you're still in command mode, so press _u_ - and you've magically undone the last change you made. Neat huh?
+Why? Well, you are in normal mode and _33dd_ is a command that says "delete 33 lines". Now, you're still in normal mode, so press _u_ - and you've magically undone the last change you made. Neat huh?
 
 Now you know the three basic tricks for a newbie to `vim`:
 
-* _Esc_ _Esc_ always gets you back to "command mode"
-* From command mode  `:q!` will always quit without saving anything you've done, and
-* From command mode `u` will undo the last action
+* _Esc_ _Esc_ always gets you back to "normal mode"
+* From normal mode  `:q!` will always quit without saving anything you've done, and
+* From normal mode `u` will undo the last action
 
 So, here's some useful, productive things to do:
 
-* Finding things: From command mode, type `G` to get to the bottom of the file, then `gg` to get to the top. Let's search for references to "sun", type `/sun` to find the first instance, then press _n_ repeatedly to step through all the next occurrences. Now go to the top of the file (_gg_ remember) and try searching for "_Apple_" or "_Microsoft_".
+* Finding things: From normal mode, type `G` to get to the bottom of the file, then `gg` to get to the top. Let's search for references to "sun", type `/sun` to find the first instance, then press _n_ repeatedly to step through all the next occurrences. Now go to the top of the file (_gg_ remember) and try searching for "_Apple_" or "_Microsoft_".
 * Cutting and pasting: Go back up to the top of the file (with _gg_) and look at the first few lines of comments (the ones with "#" as the first character.  Play around with cutting some of these out and pasting them back. To do this simply position the cursor on a line, then (for example),  type _11dd_ to delete 11 lines, then immediately paste them back in by pressing _P_ - and then move down the file a bit and paste the same 11 lines in there again with _P_
-* Inserting text: Move anywhere in the file and press _i_ to get into "insert mode" (it may show at the bottom of the screen) and start typing - and _Esc_ _Esc_ to get back into command mode when you're done.
-* Writing your changes to disk: From command mode type `:w` or `:wq` to “write and quit”. 
+* Inserting text: Move anywhere in the file and press _i_ to get into "insert mode" (it may show at the bottom of the screen) and start typing - and _Esc_ _Esc_ to get back into normal mode when you're done.
+* Writing your changes to disk: From normal mode type `:w` or `:wq` to “write and quit”. 
 
 This is as much as you ever _need_ to learn about `vi` - but there's an enormous amount more you could learn if you had the time. Your next step should be to run `vimtutor` - this official tutorial should always be installed, and takes only 30 minutes.
 


### PR DESCRIPTION
Changed "command mode" to "normal mode" as that is the way it's represented in the docs, and added a short explanation of what each mode does, to better convey the message that "command mode" gives, but "normal mode" doesn't.
Another minor change is changing the first appearance of "editing mode" to "insert mode", as it was already referenced as such in line 64 (In my edit, 66).

Not an important edit, the message remains unchanged.
However, and I know this is my personal opinion, I believe that using the official names of the modes can be helpful, even more if we consider things like how mappings in normal mode (`n[nore]map`) and the help pages are more easily understood that way.
Thought I'd try to make a PR.