### PR TITLE
Separated commands to improve readability

### DIFF
--- a/15.md
+++ b/15.md
@@ -71,9 +71,12 @@ Ubuntu also allows users to register an account and setup software in a Personal
 As an example, install and run the `neofetch` utility. This is in the standard repositories, but `neofetch -V` will show that it is version 3.4.0. If for some reason you wanted to be have the very latest version of this at all times, you could install the developer's official Neofetch PPA to your software sources by:
 
 `sudo add-apt-repository ppa:dawidd0811/neofetch`
+
+As always, after adding a repository, update your local cache of available applications:
+
 `sudo apt update`
 
-Then install it with:
+Then install the package with:
     
 `sudo apt install neofetch`
 


### PR DESCRIPTION
MD "code" syntax on adjacent lines was being rendered onto a single line (e.g. MD preview on GitHub; the Reddit posts). An alternative could be to concatenate the commands with `&&` but convention is to separate and demonstrate each individual command.