### PR TITLE
Relink guide for repository managing

### DIFF
--- a/15.md
+++ b/15.md
@@ -50,9 +50,9 @@ Instead, filter out just the packages names using `grep`, and count them using: 
 These are all the packages you could now install. Sometimes there are extra packages available in if you enable extra repositories. Most Linux distros have a similar concept, but in Ubuntu, often the "Universe" and "Multiverse" repositories are disabled by default. These are hosted at Ubuntu, but with less support, and Multiverse: _"contains software which has been classified as non-free ...may not include security updates"_. Examples of useful tools in Multiverse might include the compression utilities `rar` and `lha`, and the network performance tool `netperf`.
 
 To enable the "Multiverse" repository, follow the guides at:
-* Repositories/Ubuntu (Community wiki) (https://help.ubuntu.com/community/Repositories/Ubuntu)
+* Repositories/Ubuntu (Community wiki for GUI) (https://help.ubuntu.com/community/Repositories/Ubuntu)
 
-* Ubuntu Server Guide (https://help.ubuntu.com/lts/serverguide/configuration.html)
+* Repositories/CommandLine (Community wiki for command line) (https://help.ubuntu.com/community/Repositories/CommandLine)
 
 After adding this, update your local cache of available applications:
 


### PR DESCRIPTION
The previous link for the second listed guide (the one labeled *Ubuntu Server Guide*) appears to redirect to https://ubuntu.com/server/docs now.
Since the other guide links to instructions for GUI tools, I was looking for the command line instructions and found them in the updated link.