### PR TITLE
Changed small 'l' to capital 'L'

### DIFF
--- a/12.md
+++ b/12.md
@@ -35,7 +35,7 @@ By contrast, setting up your server for any of the other protocols will require 
 
 ## SFTP client software
 
-What’s required to use SFTP is some client software. A command-line client (unsurprisingly called _sftp_) comes standard on every Apple OSX or Linux system. If you're using a Linux desktop, you also have a built-in GUI client via your file manager. This will allow you to easily attach to remote servers via SFTP. (For the Nautilus file manager for example, press ctrl + l to bring up the 'location window" and type: _sftp://username@myserver-address_).
+What’s required to use SFTP is some client software. A command-line client (unsurprisingly called _sftp_) comes standard on every Apple OSX or Linux system. If you're using a Linux desktop, you also have a built-in GUI client via your file manager. This will allow you to easily attach to remote servers via SFTP. (For the Nautilus file manager for example, press ctrl + L to bring up the 'location window" and type: _sftp://username@myserver-address_).
 
 Although Windows and Apple macOS have no built-in GUI client there are  a wide range of third-party options available, both free and commercial. If you don't already have such a client installed, then choose one such as:
 * WinSCP or FileZilla  - for Windows users


### PR DESCRIPTION
Small 'l' appeared like capital 'I' in markdown. Changed it to 'L' to avoid any confusion.